### PR TITLE
Fix sites.assets broken link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -62,7 +62,7 @@ collections:
 analytics_adobe: ""
 analytics_google: ""
 analytics_google_anonymize_ip: ""
-assets: "https://wet-boew.github.io/themes-dist"
+assets: "https://wet-boew.github.io/themes-dist/GCWeb"
 baseurl: ""
 css_inline: false # Will insert all styles into a single <style> block in the <head> element and remove the style <link> reference
 description:


### PR DESCRIPTION
Fix a recent broken link after we updated the GCWeb build system. The GCWeb Jekyll implementation version 1.1.0 was using the deprecated file structure of WET4.

After this PR is merged, we will be able to release v1.1.1 based on "develop-v1.x" branch