### PR TITLE
Remove duplicate content from splash page

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -20,35 +20,14 @@
     fr: Gouvernement du Canada, services
   title: Canada.ca
 ---
-<div class="sp-hb">
-	<div class="sp-bx col-xs-12">
-		<h1 property="name" class="wb-inv">{{ page.title }}</h1>
-		<div class="row">
-			<div class="col-xs-11 col-md-8" property="publisher" resource="#wb-publisher" typeof="GovernmentOrganization">
-				<img src="https://wet-boew.github.io/themes-dist/GCWeb/assets/sig-spl.svg" width="283" alt="Government of Canada" property="logo" /><span class="wb-inv"> / <span lang="fr">Gouvernement du Canada</span></span>
-				<meta property="name" content="Government of Canada" />
-				<meta property="areaServed" typeOf="Country" content="Canada" />
-			</div>
-		</div>
-		<div class="row">
-			<section class="col-xs-6 text-right">
-				<h2 class="wb-inv">Government of Canada</h2>
-				<p><a href="./en/index.html" class="btn btn-primary">English</a></p>
-			</section>
-			<section class="col-xs-6" lang="fr">
-				<h2 class="wb-inv">Gouvernement du Canada</h2>
-				<p><a href="./fr/index.html" class="btn btn-primary">Français</a></p>
-			</section>
-		</div>
-	</div>
-	<div class="sp-bx-bt col-xs-12">
-		<div class="row">
-			<div class="col-xs-7 col-md-8">
-				<a href="https://www.canada.ca/en/transparency/terms.html" class="sp-lk">Terms and conditions</a> <span class="glyphicon glyphicon-asterisk"></span> <a href="https://www.canada.ca/fr/transparence/avis.html" class="sp-lk" lang="fr">Avis</a>
-			</div>
-			<div class="col-xs-5 col-md-4 text-right mrgn-bttm-md">
-				<img src="https://wet-boew.github.io/themes-dist/GCWeb/assets/wmms-spl.svg" width="127" alt="Symbol of the Government of Canada" /><span class="wb-inv"> / <span lang="fr">Symbole du gouvernement du Canada</span></span>
-			</div>
-		</div>
-	</div>
+
+<div class="row">
+	<section class="col-xs-6 text-right">
+		<h2 class="wb-inv">Government of Canada</h2>
+		<p><a href="./en/index.html" class="btn btn-primary">English</a></p>
+	</section>
+	<section class="col-xs-6" lang="fr">
+		<h2 class="wb-inv">Gouvernement du Canada</h2>
+		<p><a href="./fr/index.html" class="btn btn-primary">Français</a></p>
+	</section>
 </div>


### PR DESCRIPTION
Not sure what the intention is with the latest splash page template but there was data duplicated in index.md. I removed that. For your consideration.