### PR TITLE
Add relative_url in language switcher

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,7 +47,7 @@ verbose: false
 # 7. Site settings
 analytics_adobe: ""
 assets: "https://wet-boew.github.io/themes-dist"
-baseurl: ""
+baseurl: "" # If the site is in a subdirectory like on github.io then set this to "/dirname"
 description:
   en: "Jekyll variant for GCWeb theme" # English site description and default description
   fr: "Adaption Jekyll du theme GCWeb" # French site description and default description

--- a/_includes/language/languagetoggle.html
+++ b/_includes/language/languagetoggle.html
@@ -2,7 +2,7 @@
 	<h2 class="wb-inv">{{ i18nText-language }}</h2>
 	<ul class="list-inline mrgn-bttm-0">
 		<li>
-			<a lang="{{ i18nText-altLang }}" hreflang="{{ i18nText-altLang }}" href="{{ page.altLangPage }}">
+			<a lang="{{ i18nText-altLang }}" hreflang="{{ i18nText-altLang }}" href="{{ page.altLangPage | relative_url }}">
 				<span class="hidden-xs" translate="no">{{ i18nText-altLanguage }}</span>
 				<abbr title="{{ i18nText-altLanguage }}" translate="no" class="visible-xs h3 mrgn-tp-sm mrgn-bttm-0 text-uppercase">{{ i18nText-altLang }}</abbr>
 			</a>


### PR DESCRIPTION
I've been working on a little [example site](https://nrcan.github.io/gcweb-jekyll-demo/) using the gcweb jekyll theme for internal use and noticed that the alt lang url doesn't use the relative_url filter like the breadcrumbs do.

That means for sites using subdirectories like most github pages the alt lag url omits the baseurl.  For sites running at the root there's no impact from this bug.

I added a note in the default _config.yml file about the value you might set baseurl to as well.

**Possible risk:** Impact on a site is minimal but for content that has already been created where the baseurl has been manually addded to the altlang url then the content would have to be updated.